### PR TITLE
General cleanup around TPS monitor

### DIFF
--- a/tps-monitor/tpsmon/infuxdbmetrics.go
+++ b/tps-monitor/tpsmon/infuxdbmetrics.go
@@ -23,8 +23,7 @@ type InfluxdbMetricsService struct {
 }
 
 func NewInfluxdbService(ep string, token string, org string, bucket string, point string, tags string) (*InfluxdbMetricsService, error) {
-	_, err := url.Parse(ep)
-	if err != nil {
+	if _, err := url.Parse(ep); err != nil {
 		return nil, err
 	}
 	tagsMap := stringToTags(tags)
@@ -49,8 +48,7 @@ func (id *InfluxdbMetricsService) PushMetrics(tm time.Time, tps uint64, txns uin
 			"blocks":       float64(blocks),
 		},
 		tm)
-	err := id.writeApi.WritePoint(context.Background(), p)
-	if err != nil {
+	if err := id.writeApi.WritePoint(context.Background(), p); err != nil {
 		log.Errorf("influxdb write failed error: %v", err)
 		id.makeClient()
 		return

--- a/tps-monitor/tpsmon/promethmetrics.go
+++ b/tps-monitor/tpsmon/promethmetrics.go
@@ -23,7 +23,7 @@ func NewPrometheusMetricsService(port int) *PrometheusMetricsService {
 			Namespace: "Quorum",
 			Subsystem: "TransactionProcessing",
 			Name:      "TPS",
-			Help:      "Tranasctions processed per second",
+			Help:      "Transactions processed per second",
 		}),
 		blocksGauge: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "Quorum",

--- a/tps-monitor/tpsmon/server.go
+++ b/tps-monitor/tpsmon/server.go
@@ -28,7 +28,6 @@ func NewTPSServer(tm *TPSMonitor, port int) TPSServer {
 	}
 	go s.Start()
 	return s
-
 }
 
 func (s TPSServer) Start() {


### PR DESCRIPTION
Contains some general, non-functional changes around the TPS monitor, including:

- using base 0 for `strconv.ParseUint`. Using base 0 will cause it to infer the correct base from the strings prefix, in this case `0x` meaning we don't need to replace it ourselves
- inlining error handling
- reducing shutdown interrupts to 5, added panic if max interrupts reached

NOTE: these changes haven't been tested, if you think something won't work, then please do change it back