### PR TITLE
Fix influxdb DB error

### DIFF
--- a/Dockerfile_jmeter
+++ b/Dockerfile_jmeter
@@ -1,0 +1,25 @@
+FROM alpine:3.12
+#inspired by https://hub.docker.com/r/justb4/jmeter/Dockerfile
+ARG JMETER_VERSION="5.2.1"
+ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}
+ENV	JMETER_BIN	${JMETER_HOME}/bin
+ENV	JMETER_DOWNLOAD_URL  https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.tgz
+
+RUN    apk update \
+	&& apk upgrade \
+	&& apk add ca-certificates \
+	&& update-ca-certificates \
+	&& apk add --update openjdk8-jre tzdata curl unzip bash \
+	&& apk add --no-cache nss \
+	&& rm -rf /var/cache/apk/* \
+	&& mkdir -p /tmp/dependencies  \
+	&& curl -L --silent ${JMETER_DOWNLOAD_URL} >  /tmp/dependencies/apache-jmeter-${JMETER_VERSION}.tgz  \
+	&& mkdir -p /opt  \
+	&& tar -xzf /tmp/dependencies/apache-jmeter-${JMETER_VERSION}.tgz -C /opt  \
+	&& rm -rf /tmp/dependencies
+
+ENV PATH $PATH:$JMETER_BIN
+
+WORKDIR	${JMETER_HOME}
+
+ENTRYPOINT ["jmeter.sh"]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The prerequisites for each of the above scenario is as listed below:
 
 * **Scenario 2:**
 > * `Jmeter`: `Jmeter` installed on the machine from where the test scripts are being executed. If you using MacOS use `brew install jmeter`. For other OS, please refer [here](https://jmeter.apache.org/download_jmeter.cgi) for further details
-> * `influxDB`: By default we push the metrics to influxDB. Refer [here](https://docs.influxdata.com/influxdb/v1.8/introduction/install/) for further details on `influxDB` installation and [here](jmeter-test/README.md#disabling-influxdb) for instructions to run without metrics push to `influxDB`. 
+> * `influxDB`: Requires influxDB 1.8.2. By default, we push the metrics to influxDB. Refer [here](https://docs.influxdata.com/influxdb/v1.8/introduction/install/) for further details on `influxDB` installation and [here](jmeter-test/README.md#disabling-influxdb) for instructions to run without metrics push to `influxDB`. 
 > * A running Quorum network on which the tests to be executed
 
 * **Scenario 3:**

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - influxdb
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:7.2.0
     container_name: grafana
     restart: unless-stopped
     ports:
@@ -37,7 +37,7 @@ services:
       - influxdb
 
   influxdb:
-    image: influxdb
+    image: influxdb:1.8.2
     container_name: influxdb
     restart: unless-stopped
     ports:

--- a/stresstest-aws/scripts/test/docker-compose-graf-inflx.yml
+++ b/stresstest-aws/scripts/test/docker-compose-graf-inflx.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:7.2.0
     container_name: grafana
     restart: unless-stopped
     ports:
@@ -16,7 +16,7 @@ services:
       - ./quorum-jmeter-dashboard.json:/etc/grafana/provisioning/dashboards/quorum-jmeter-dashboard.json
 
   influxdb:
-    image: influxdb
+    image: influxdb:1.8.2
     container_name: influxdb
     restart: unless-stopped
     ports:


### PR DESCRIPTION
In scenario1 and scenario4, we are pulling latest image of influxdb(v2) which accepts only token based authorization. Influxdb(v2) is not allowing jmeter and tps-monitor to write stats as they are trying to access it with userid/password instead of token. As a result of this issue we are not able to visualize the stats in grafana dashboard.

To fix this:
update docker influxdb version to 1.8.2(it supports accepts accessing db with userid/password) and grafana version to 7.2.0(our default dashboards were tested with this version) in scenario1 and scenario4.