### PR TITLE
fix: change in how tessera 21.7 is launched

### DIFF
--- a/stresstest-aws/docker-compose.tf
+++ b/stresstest-aws/docker-compose.tf
@@ -100,7 +100,7 @@ x-tx-manager-def:
     - -c
     - |
       rm -f ${local.tm_dir_container_path}/tm.ipc
-      java -Xms1024M -Xmx2048M -jar /tessera/tessera-app.jar -configfile ${local.tm_dir_container_path}/config.json
+      /tessera/bin/tessera -configfile ${local.tm_dir_container_path}/config.json
 %{endif~}
 services:
   node:


### PR DESCRIPTION
With the new release of Tessera 21.7, the way it is launched is incompatible.